### PR TITLE
NF: Remove COMMAND_ prefix from ViewerCommand

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.kt
@@ -49,7 +49,7 @@ class PeripheralKeymapTest {
         assertThat<List<ViewerCommand>>(processed, hasSize(1))
         assertThat(
             processed[0],
-            `is`(ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE1)
+            `is`(ViewerCommand.FLIP_OR_ANSWER_EASE1)
         )
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1636,101 +1636,101 @@ abstract class AbstractFlashcardViewer :
     }
 
     override fun executeCommand(which: ViewerCommand, fromGesture: Gesture?): Boolean {
-        return if (isControlBlocked() && which !== ViewerCommand.COMMAND_EXIT) {
+        return if (isControlBlocked() && which !== ViewerCommand.EXIT) {
             false
         } else when (which) {
-            ViewerCommand.COMMAND_NOTHING -> true
-            ViewerCommand.COMMAND_SHOW_ANSWER -> {
+            ViewerCommand.NOTHING -> true
+            ViewerCommand.SHOW_ANSWER -> {
                 if (sDisplayAnswer) {
                     return false
                 }
                 displayCardAnswer()
                 true
             }
-            ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE1 -> {
+            ViewerCommand.FLIP_OR_ANSWER_EASE1 -> {
                 flipOrAnswerCard(EASE_1)
                 true
             }
-            ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE2 -> {
+            ViewerCommand.FLIP_OR_ANSWER_EASE2 -> {
                 flipOrAnswerCard(EASE_2)
                 true
             }
-            ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE3 -> {
+            ViewerCommand.FLIP_OR_ANSWER_EASE3 -> {
                 flipOrAnswerCard(EASE_3)
                 true
             }
-            ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE4 -> {
+            ViewerCommand.FLIP_OR_ANSWER_EASE4 -> {
                 flipOrAnswerCard(EASE_4)
                 true
             }
-            ViewerCommand.COMMAND_FLIP_OR_ANSWER_RECOMMENDED -> {
+            ViewerCommand.FLIP_OR_ANSWER_RECOMMENDED -> {
                 flipOrAnswerCard(getRecommendedEase(false))
                 true
             }
-            ViewerCommand.COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED -> {
+            ViewerCommand.FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED -> {
                 flipOrAnswerCard(getRecommendedEase(true))
                 true
             }
-            ViewerCommand.COMMAND_EXIT -> {
+            ViewerCommand.EXIT -> {
                 closeReviewer(RESULT_DEFAULT, false)
                 true
             }
-            ViewerCommand.COMMAND_UNDO -> {
+            ViewerCommand.UNDO -> {
                 if (!isUndoAvailable) {
                     return false
                 }
                 undo()
                 true
             }
-            ViewerCommand.COMMAND_EDIT -> {
+            ViewerCommand.EDIT -> {
                 editCard(fromGesture)
                 true
             }
-            ViewerCommand.COMMAND_TAG -> {
+            ViewerCommand.TAG -> {
                 showTagsDialog()
                 true
             }
-            ViewerCommand.COMMAND_BURY_CARD -> buryCard()
-            ViewerCommand.COMMAND_BURY_NOTE -> buryNote()
-            ViewerCommand.COMMAND_SUSPEND_CARD -> suspendCard()
-            ViewerCommand.COMMAND_SUSPEND_NOTE -> suspendNote()
-            ViewerCommand.COMMAND_DELETE -> {
+            ViewerCommand.BURY_CARD -> buryCard()
+            ViewerCommand.BURY_NOTE -> buryNote()
+            ViewerCommand.SUSPEND_CARD -> suspendCard()
+            ViewerCommand.SUSPEND_NOTE -> suspendNote()
+            ViewerCommand.DELETE -> {
                 showDeleteNoteDialog()
                 true
             }
-            ViewerCommand.COMMAND_PLAY_MEDIA -> {
+            ViewerCommand.PLAY_MEDIA -> {
                 playSounds(true)
                 true
             }
-            ViewerCommand.COMMAND_PAGE_UP -> {
+            ViewerCommand.PAGE_UP -> {
                 onPageUp()
                 true
             }
-            ViewerCommand.COMMAND_PAGE_DOWN -> {
+            ViewerCommand.PAGE_DOWN -> {
                 onPageDown()
                 true
             }
-            ViewerCommand.COMMAND_ABORT_AND_SYNC -> {
+            ViewerCommand.ABORT_AND_SYNC -> {
                 abortAndSync()
                 true
             }
-            ViewerCommand.COMMAND_RECORD_VOICE -> {
+            ViewerCommand.RECORD_VOICE -> {
                 recordVoice()
                 true
             }
-            ViewerCommand.COMMAND_REPLAY_VOICE -> {
+            ViewerCommand.REPLAY_VOICE -> {
                 replayVoice()
                 true
             }
-            ViewerCommand.COMMAND_TOGGLE_WHITEBOARD -> {
+            ViewerCommand.TOGGLE_WHITEBOARD -> {
                 toggleWhiteboard()
                 true
             }
-            ViewerCommand.COMMAND_SHOW_HINT -> {
+            ViewerCommand.SHOW_HINT -> {
                 loadUrlInViewer("javascript: showHint();")
                 true
             }
-            ViewerCommand.COMMAND_SHOW_ALL_HINTS -> {
+            ViewerCommand.SHOW_ALL_HINTS -> {
                 loadUrlInViewer("javascript: showAllHints();")
                 true
             }
@@ -2301,7 +2301,7 @@ abstract class AbstractFlashcardViewer :
                 if (!mAnkiDroidJsAPI!!.isInit(AnkiDroidJsAPIConstants.MARK_CARD, AnkiDroidJsAPIConstants.ankiJsErrorCodeMarkCard)) {
                     return true
                 }
-                executeCommand(ViewerCommand.COMMAND_MARK)
+                executeCommand(ViewerCommand.MARK)
                 return true
             }
             // flag card (blue, green, orange, red) using javascript from AnkiDroid webview
@@ -2311,23 +2311,23 @@ abstract class AbstractFlashcardViewer :
                 }
                 return when (url.replaceFirst("signal:flag_".toRegex(), "")) {
                     "none" -> {
-                        executeCommand(ViewerCommand.COMMAND_UNSET_FLAG)
+                        executeCommand(ViewerCommand.UNSET_FLAG)
                         true
                     }
                     "red" -> {
-                        executeCommand(ViewerCommand.COMMAND_TOGGLE_FLAG_RED)
+                        executeCommand(ViewerCommand.TOGGLE_FLAG_RED)
                         true
                     }
                     "orange" -> {
-                        executeCommand(ViewerCommand.COMMAND_TOGGLE_FLAG_ORANGE)
+                        executeCommand(ViewerCommand.TOGGLE_FLAG_ORANGE)
                         true
                     }
                     "green" -> {
-                        executeCommand(ViewerCommand.COMMAND_TOGGLE_FLAG_GREEN)
+                        executeCommand(ViewerCommand.TOGGLE_FLAG_GREEN)
                         true
                     }
                     "blue" -> {
-                        executeCommand(ViewerCommand.COMMAND_TOGGLE_FLAG_BLUE)
+                        executeCommand(ViewerCommand.TOGGLE_FLAG_BLUE)
                         true
                     }
                     else -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1155,51 +1155,51 @@ open class Reviewer : AbstractFlashcardViewer() {
     }
 
     override fun executeCommand(which: ViewerCommand, fromGesture: Gesture?): Boolean {
-        if (isControlBlocked() && which !== ViewerCommand.COMMAND_EXIT) {
+        if (isControlBlocked() && which !== ViewerCommand.EXIT) {
             return false
         }
         when (which) {
-            ViewerCommand.COMMAND_TOGGLE_FLAG_RED -> {
+            ViewerCommand.TOGGLE_FLAG_RED -> {
                 toggleFlag(CardMarker.FLAG_RED)
                 return true
             }
-            ViewerCommand.COMMAND_TOGGLE_FLAG_ORANGE -> {
+            ViewerCommand.TOGGLE_FLAG_ORANGE -> {
                 toggleFlag(CardMarker.FLAG_ORANGE)
                 return true
             }
-            ViewerCommand.COMMAND_TOGGLE_FLAG_GREEN -> {
+            ViewerCommand.TOGGLE_FLAG_GREEN -> {
                 toggleFlag(CardMarker.FLAG_GREEN)
                 return true
             }
-            ViewerCommand.COMMAND_TOGGLE_FLAG_BLUE -> {
+            ViewerCommand.TOGGLE_FLAG_BLUE -> {
                 toggleFlag(CardMarker.FLAG_BLUE)
                 return true
             }
-            ViewerCommand.COMMAND_TOGGLE_FLAG_PINK -> {
+            ViewerCommand.TOGGLE_FLAG_PINK -> {
                 toggleFlag(CardMarker.FLAG_PINK)
                 return true
             }
-            ViewerCommand.COMMAND_TOGGLE_FLAG_TURQUOISE -> {
+            ViewerCommand.TOGGLE_FLAG_TURQUOISE -> {
                 toggleFlag(CardMarker.FLAG_TURQUOISE)
                 return true
             }
-            ViewerCommand.COMMAND_TOGGLE_FLAG_PURPLE -> {
+            ViewerCommand.TOGGLE_FLAG_PURPLE -> {
                 toggleFlag(CardMarker.FLAG_PURPLE)
                 return true
             }
-            ViewerCommand.COMMAND_UNSET_FLAG -> {
+            ViewerCommand.UNSET_FLAG -> {
                 onFlag(mCurrentCard, CardMarker.FLAG_NONE)
                 return true
             }
-            ViewerCommand.COMMAND_MARK -> {
+            ViewerCommand.MARK -> {
                 onMark(mCurrentCard)
                 return true
             }
-            ViewerCommand.COMMAND_ADD_NOTE -> {
+            ViewerCommand.ADD_NOTE -> {
                 addNote(fromGesture)
                 return true
             }
-            ViewerCommand.COMMAND_CARD_INFO -> {
+            ViewerCommand.CARD_INFO -> {
                 openCardInfo(fromGesture)
                 return true
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/Gesture.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/Gesture.kt
@@ -41,21 +41,21 @@ enum class Gesture(
     private val preferenceKey: String,
     private val preferenceDefault: ViewerCommand
 ) {
-    SWIPE_UP(R.string.gestures_swipe_up, "gestureSwipeUp", ViewerCommand.COMMAND_EDIT),
-    SWIPE_DOWN(R.string.gestures_swipe_down, "gestureSwipeDown", ViewerCommand.COMMAND_NOTHING),
-    SWIPE_LEFT(R.string.gestures_swipe_left, "gestureSwipeLeft", ViewerCommand.COMMAND_UNDO),
-    SWIPE_RIGHT(R.string.gestures_swipe_right, "gestureSwipeRight", ViewerCommand.COMMAND_EXIT),
-    LONG_TAP(R.string.gestures_long_tap, "gestureLongclick", ViewerCommand.COMMAND_NOTHING),
-    DOUBLE_TAP(R.string.gestures_double_tap, "gestureDoubleTap", ViewerCommand.COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED),
-    TAP_TOP_LEFT(R.string.gestures_corner_tap_top_left, "gestureTapTopLeft", ViewerCommand.COMMAND_NOTHING),
-    TAP_TOP(R.string.gestures_tap_top, "gestureTapTop", ViewerCommand.COMMAND_BURY_CARD),
-    TAP_TOP_RIGHT(R.string.gestures_corner_tap_top_right, "gestureTapTopRight", ViewerCommand.COMMAND_NOTHING),
-    TAP_LEFT(R.string.gestures_tap_left, "gestureTapLeft", ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE2),
-    TAP_CENTER(R.string.gestures_corner_tap_middle_center, "gestureTapCenter", ViewerCommand.COMMAND_NOTHING),
-    TAP_RIGHT(R.string.gestures_tap_right, "gestureTapRight", ViewerCommand.COMMAND_FLIP_OR_ANSWER_RECOMMENDED),
-    TAP_BOTTOM_LEFT(R.string.gestures_corner_tap_bottom_left, "gestureTapBottomLeft", ViewerCommand.COMMAND_NOTHING),
-    TAP_BOTTOM(R.string.gestures_tap_bottom, "gestureTapBottom", ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE1),
-    TAP_BOTTOM_RIGHT(R.string.gestures_corner_tap_bottom_right, "gestureTapBottomRight", ViewerCommand.COMMAND_NOTHING);
+    SWIPE_UP(R.string.gestures_swipe_up, "gestureSwipeUp", ViewerCommand.EDIT),
+    SWIPE_DOWN(R.string.gestures_swipe_down, "gestureSwipeDown", ViewerCommand.NOTHING),
+    SWIPE_LEFT(R.string.gestures_swipe_left, "gestureSwipeLeft", ViewerCommand.UNDO),
+    SWIPE_RIGHT(R.string.gestures_swipe_right, "gestureSwipeRight", ViewerCommand.EXIT),
+    LONG_TAP(R.string.gestures_long_tap, "gestureLongclick", ViewerCommand.NOTHING),
+    DOUBLE_TAP(R.string.gestures_double_tap, "gestureDoubleTap", ViewerCommand.FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED),
+    TAP_TOP_LEFT(R.string.gestures_corner_tap_top_left, "gestureTapTopLeft", ViewerCommand.NOTHING),
+    TAP_TOP(R.string.gestures_tap_top, "gestureTapTop", ViewerCommand.BURY_CARD),
+    TAP_TOP_RIGHT(R.string.gestures_corner_tap_top_right, "gestureTapTopRight", ViewerCommand.NOTHING),
+    TAP_LEFT(R.string.gestures_tap_left, "gestureTapLeft", ViewerCommand.FLIP_OR_ANSWER_EASE2),
+    TAP_CENTER(R.string.gestures_corner_tap_middle_center, "gestureTapCenter", ViewerCommand.NOTHING),
+    TAP_RIGHT(R.string.gestures_tap_right, "gestureTapRight", ViewerCommand.FLIP_OR_ANSWER_RECOMMENDED),
+    TAP_BOTTOM_LEFT(R.string.gestures_corner_tap_bottom_left, "gestureTapBottomLeft", ViewerCommand.NOTHING),
+    TAP_BOTTOM(R.string.gestures_tap_bottom, "gestureTapBottom", ViewerCommand.FLIP_OR_ANSWER_EASE1),
+    TAP_BOTTOM_RIGHT(R.string.gestures_corner_tap_bottom_right, "gestureTapBottomRight", ViewerCommand.NOTHING);
 
     fun fromPreference(prefs: SharedPreferences): ViewerCommand {
         val value = prefs.getString(preferenceKey, null) ?: return preferenceDefault

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.kt
@@ -16,7 +16,7 @@
 package com.ichi2.anki.cardviewer
 
 import android.content.SharedPreferences
-import com.ichi2.anki.cardviewer.ViewerCommand.COMMAND_NOTHING
+import com.ichi2.anki.cardviewer.ViewerCommand.NOTHING
 import com.ichi2.anki.reviewer.GestureMapper
 
 class GestureProcessor(private val processor: ViewerCommand.CommandProcessor?) {
@@ -115,7 +115,7 @@ class GestureProcessor(private val processor: ViewerCommand.CommandProcessor?) {
             Gesture.TAP_BOTTOM_RIGHT -> gestureTapBottomRight
             Gesture.DOUBLE_TAP -> gestureDoubleTap
             Gesture.LONG_TAP -> gestureLongclick
-            else -> COMMAND_NOTHING
+            else -> NOTHING
         }
     }
 
@@ -129,7 +129,7 @@ class GestureProcessor(private val processor: ViewerCommand.CommandProcessor?) {
             return false
         }
         for (gesture in gestures) {
-            if (mapGestureToCommand(gesture) != COMMAND_NOTHING) {
+            if (mapGestureToCommand(gesture) != NOTHING) {
                 return true
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
@@ -33,43 +33,43 @@ import java.util.stream.Collectors
 
 /** Abstraction: Discuss moving many of these to 'Reviewer'  */
 enum class ViewerCommand(val resourceId: Int, private val preferenceValue: Int) {
-    COMMAND_NOTHING(R.string.nothing, 0),
-    COMMAND_SHOW_ANSWER(R.string.show_answer, 1),
-    COMMAND_FLIP_OR_ANSWER_EASE1(R.string.gesture_answer_1, 2),
-    COMMAND_FLIP_OR_ANSWER_EASE2(R.string.gesture_answer_2, 3),
-    COMMAND_FLIP_OR_ANSWER_EASE3(R.string.gesture_answer_3, 4),
-    COMMAND_FLIP_OR_ANSWER_EASE4(R.string.gesture_answer_4, 5),
-    COMMAND_FLIP_OR_ANSWER_RECOMMENDED(R.string.gesture_answer_green, 6),
-    COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED(R.string.gesture_answer_better_recommended, 7),
-    COMMAND_UNDO(R.string.undo, 8),
-    COMMAND_EDIT(R.string.cardeditor_title_edit_card, 9),
-    COMMAND_MARK(R.string.menu_mark_note, 10),
-    COMMAND_BURY_CARD(R.string.menu_bury, 12),
-    COMMAND_SUSPEND_CARD(R.string.menu_suspend_card, 13),
-    COMMAND_DELETE(R.string.menu_delete_note, 14), // 15 is unused.
-    COMMAND_PLAY_MEDIA(R.string.gesture_play, 16),
-    COMMAND_EXIT(R.string.gesture_abort_learning, 17),
-    COMMAND_BURY_NOTE(R.string.menu_bury_note, 18),
-    COMMAND_SUSPEND_NOTE(R.string.menu_suspend_note, 19),
-    COMMAND_TOGGLE_FLAG_RED(R.string.gesture_flag_red, 20),
-    COMMAND_TOGGLE_FLAG_ORANGE(R.string.gesture_flag_orange, 21),
-    COMMAND_TOGGLE_FLAG_GREEN(R.string.gesture_flag_green, 22),
-    COMMAND_TOGGLE_FLAG_BLUE(R.string.gesture_flag_blue, 23),
-    COMMAND_TOGGLE_FLAG_PINK(R.string.gesture_flag_pink, 38),
-    COMMAND_TOGGLE_FLAG_TURQUOISE(R.string.gesture_flag_turquoise, 39),
-    COMMAND_TOGGLE_FLAG_PURPLE(R.string.gesture_flag_purple, 40),
-    COMMAND_UNSET_FLAG(R.string.gesture_flag_remove, 24),
-    COMMAND_PAGE_UP(R.string.gesture_page_up, 30),
-    COMMAND_PAGE_DOWN(R.string.gesture_page_down, 31),
-    COMMAND_TAG(R.string.add_tag, 32),
-    COMMAND_CARD_INFO(R.string.card_info_title, 33),
-    COMMAND_ABORT_AND_SYNC(R.string.gesture_abort_sync, 34),
-    COMMAND_RECORD_VOICE(R.string.record_voice, 35),
-    COMMAND_REPLAY_VOICE(R.string.replay_voice, 36),
-    COMMAND_TOGGLE_WHITEBOARD(R.string.gesture_toggle_whiteboard, 37),
-    COMMAND_SHOW_HINT(R.string.gesture_show_hint, 41),
-    COMMAND_SHOW_ALL_HINTS(R.string.gesture_show_all_hints, 42),
-    COMMAND_ADD_NOTE(R.string.menu_add_note, 43);
+    NOTHING(R.string.nothing, 0),
+    SHOW_ANSWER(R.string.show_answer, 1),
+    FLIP_OR_ANSWER_EASE1(R.string.gesture_answer_1, 2),
+    FLIP_OR_ANSWER_EASE2(R.string.gesture_answer_2, 3),
+    FLIP_OR_ANSWER_EASE3(R.string.gesture_answer_3, 4),
+    FLIP_OR_ANSWER_EASE4(R.string.gesture_answer_4, 5),
+    FLIP_OR_ANSWER_RECOMMENDED(R.string.gesture_answer_green, 6),
+    FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED(R.string.gesture_answer_better_recommended, 7),
+    UNDO(R.string.undo, 8),
+    EDIT(R.string.cardeditor_title_edit_card, 9),
+    MARK(R.string.menu_mark_note, 10),
+    BURY_CARD(R.string.menu_bury, 12),
+    SUSPEND_CARD(R.string.menu_suspend_card, 13),
+    DELETE(R.string.menu_delete_note, 14), // 15 is unused.
+    PLAY_MEDIA(R.string.gesture_play, 16),
+    EXIT(R.string.gesture_abort_learning, 17),
+    BURY_NOTE(R.string.menu_bury_note, 18),
+    SUSPEND_NOTE(R.string.menu_suspend_note, 19),
+    TOGGLE_FLAG_RED(R.string.gesture_flag_red, 20),
+    TOGGLE_FLAG_ORANGE(R.string.gesture_flag_orange, 21),
+    TOGGLE_FLAG_GREEN(R.string.gesture_flag_green, 22),
+    TOGGLE_FLAG_BLUE(R.string.gesture_flag_blue, 23),
+    TOGGLE_FLAG_PINK(R.string.gesture_flag_pink, 38),
+    TOGGLE_FLAG_TURQUOISE(R.string.gesture_flag_turquoise, 39),
+    TOGGLE_FLAG_PURPLE(R.string.gesture_flag_purple, 40),
+    UNSET_FLAG(R.string.gesture_flag_remove, 24),
+    PAGE_UP(R.string.gesture_page_up, 30),
+    PAGE_DOWN(R.string.gesture_page_down, 31),
+    TAG(R.string.add_tag, 32),
+    CARD_INFO(R.string.card_info_title, 33),
+    ABORT_AND_SYNC(R.string.gesture_abort_sync, 34),
+    RECORD_VOICE(R.string.record_voice, 35),
+    REPLAY_VOICE(R.string.replay_voice, 36),
+    TOGGLE_WHITEBOARD(R.string.gesture_toggle_whiteboard, 37),
+    SHOW_HINT(R.string.gesture_show_hint, 41),
+    SHOW_ALL_HINTS(R.string.gesture_show_all_hints, 42),
+    ADD_NOTE(R.string.menu_add_note, 43);
 
     companion object {
         fun fromString(value: String): ViewerCommand? {
@@ -91,7 +91,7 @@ enum class ViewerCommand(val resourceId: Int, private val preferenceValue: Int) 
     }
 
     val preferenceKey: String
-        get() = "binding_" + name.replaceFirst("COMMAND_".toRegex(), "")
+        get() = "binding_$name"
 
     fun addBinding(preferences: SharedPreferences, binding: MappableBinding) {
         val addAtStart = BiFunction { collection: MutableList<MappableBinding>, element: MappableBinding ->
@@ -116,7 +116,7 @@ enum class ViewerCommand(val resourceId: Int, private val preferenceValue: Int) 
     }
 
     private fun addBindingInternal(preferences: SharedPreferences, binding: MappableBinding, performAdd: BiFunction<MutableList<MappableBinding>, MappableBinding, Boolean>) {
-        if (this == COMMAND_NOTHING) {
+        if (this == NOTHING) {
             return
         }
         val bindings: MutableList<MappableBinding> = fromPreference(preferences, this)
@@ -129,48 +129,48 @@ enum class ViewerCommand(val resourceId: Int, private val preferenceValue: Int) 
     val defaultValue: List<MappableBinding>
         get() = // If we use the serialised format, then this adds additional coupling to the properties.
             when (this) {
-                COMMAND_FLIP_OR_ANSWER_EASE1 -> from(
+                FLIP_OR_ANSWER_EASE1 -> from(
                     keyCode(KeyEvent.KEYCODE_BUTTON_Y, CardSide.BOTH),
                     keyCode(KeyEvent.KEYCODE_1, CardSide.ANSWER), keyCode(KeyEvent.KEYCODE_NUMPAD_1, CardSide.ANSWER)
                 )
-                COMMAND_FLIP_OR_ANSWER_EASE2 -> from(
+                FLIP_OR_ANSWER_EASE2 -> from(
                     keyCode(KeyEvent.KEYCODE_BUTTON_X, CardSide.BOTH),
                     keyCode(KeyEvent.KEYCODE_2, CardSide.ANSWER), keyCode(KeyEvent.KEYCODE_NUMPAD_2, CardSide.ANSWER)
                 )
-                COMMAND_FLIP_OR_ANSWER_EASE3 -> from(
+                FLIP_OR_ANSWER_EASE3 -> from(
                     keyCode(KeyEvent.KEYCODE_BUTTON_B, CardSide.BOTH),
                     keyCode(KeyEvent.KEYCODE_3, CardSide.ANSWER), keyCode(KeyEvent.KEYCODE_NUMPAD_3, CardSide.ANSWER)
                 )
-                COMMAND_FLIP_OR_ANSWER_EASE4 -> from(
+                FLIP_OR_ANSWER_EASE4 -> from(
                     keyCode(KeyEvent.KEYCODE_BUTTON_A, CardSide.BOTH),
                     keyCode(KeyEvent.KEYCODE_4, CardSide.ANSWER), keyCode(KeyEvent.KEYCODE_NUMPAD_4, CardSide.ANSWER)
                 )
-                COMMAND_FLIP_OR_ANSWER_RECOMMENDED -> from(
+                FLIP_OR_ANSWER_RECOMMENDED -> from(
                     keyCode(KeyEvent.KEYCODE_DPAD_CENTER, CardSide.BOTH),
                     keyCode(KeyEvent.KEYCODE_SPACE, CardSide.ANSWER),
                     keyCode(KeyEvent.KEYCODE_ENTER, CardSide.ANSWER),
                     keyCode(KeyEvent.KEYCODE_NUMPAD_ENTER, CardSide.ANSWER)
                 )
-                COMMAND_EDIT -> from(keyCode(KeyEvent.KEYCODE_E, CardSide.BOTH))
-                COMMAND_MARK -> from(unicode('*', CardSide.BOTH))
-                COMMAND_BURY_CARD -> from(unicode('-', CardSide.BOTH))
-                COMMAND_BURY_NOTE -> from(unicode('=', CardSide.BOTH))
-                COMMAND_SUSPEND_CARD -> from(unicode('@', CardSide.BOTH))
-                COMMAND_SUSPEND_NOTE -> from(unicode('!', CardSide.BOTH))
-                COMMAND_PLAY_MEDIA -> from(keyCode(KeyEvent.KEYCODE_R, CardSide.BOTH), keyCode(KeyEvent.KEYCODE_F5, CardSide.BOTH))
-                COMMAND_REPLAY_VOICE -> from(keyCode(KeyEvent.KEYCODE_V, CardSide.BOTH))
-                COMMAND_RECORD_VOICE -> from(keyCode(KeyEvent.KEYCODE_V, CardSide.BOTH, shift()))
-                COMMAND_UNDO -> from(keyCode(KeyEvent.KEYCODE_Z, CardSide.BOTH))
-                COMMAND_TOGGLE_FLAG_RED -> from(keyCode(KeyEvent.KEYCODE_1, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_1, CardSide.BOTH, ctrl()))
-                COMMAND_TOGGLE_FLAG_ORANGE -> from(keyCode(KeyEvent.KEYCODE_2, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_2, CardSide.BOTH, ctrl()))
-                COMMAND_TOGGLE_FLAG_GREEN -> from(keyCode(KeyEvent.KEYCODE_3, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_3, CardSide.BOTH, ctrl()))
-                COMMAND_TOGGLE_FLAG_BLUE -> from(keyCode(KeyEvent.KEYCODE_4, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_4, CardSide.BOTH, ctrl()))
-                COMMAND_TOGGLE_FLAG_PINK -> from(keyCode(KeyEvent.KEYCODE_5, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_5, CardSide.BOTH, ctrl()))
-                COMMAND_TOGGLE_FLAG_TURQUOISE -> from(keyCode(KeyEvent.KEYCODE_6, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_6, CardSide.BOTH, ctrl()))
-                COMMAND_TOGGLE_FLAG_PURPLE -> from(keyCode(KeyEvent.KEYCODE_7, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_7, CardSide.BOTH, ctrl()))
-                COMMAND_SHOW_HINT -> from(keyCode(KeyEvent.KEYCODE_H, CardSide.BOTH))
-                COMMAND_SHOW_ALL_HINTS -> from(keyCode(KeyEvent.KEYCODE_G, CardSide.BOTH))
-                COMMAND_ADD_NOTE -> from(keyCode(KeyEvent.KEYCODE_A, CardSide.BOTH))
+                EDIT -> from(keyCode(KeyEvent.KEYCODE_E, CardSide.BOTH))
+                MARK -> from(unicode('*', CardSide.BOTH))
+                BURY_CARD -> from(unicode('-', CardSide.BOTH))
+                BURY_NOTE -> from(unicode('=', CardSide.BOTH))
+                SUSPEND_CARD -> from(unicode('@', CardSide.BOTH))
+                SUSPEND_NOTE -> from(unicode('!', CardSide.BOTH))
+                PLAY_MEDIA -> from(keyCode(KeyEvent.KEYCODE_R, CardSide.BOTH), keyCode(KeyEvent.KEYCODE_F5, CardSide.BOTH))
+                REPLAY_VOICE -> from(keyCode(KeyEvent.KEYCODE_V, CardSide.BOTH))
+                RECORD_VOICE -> from(keyCode(KeyEvent.KEYCODE_V, CardSide.BOTH, shift()))
+                UNDO -> from(keyCode(KeyEvent.KEYCODE_Z, CardSide.BOTH))
+                TOGGLE_FLAG_RED -> from(keyCode(KeyEvent.KEYCODE_1, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_1, CardSide.BOTH, ctrl()))
+                TOGGLE_FLAG_ORANGE -> from(keyCode(KeyEvent.KEYCODE_2, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_2, CardSide.BOTH, ctrl()))
+                TOGGLE_FLAG_GREEN -> from(keyCode(KeyEvent.KEYCODE_3, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_3, CardSide.BOTH, ctrl()))
+                TOGGLE_FLAG_BLUE -> from(keyCode(KeyEvent.KEYCODE_4, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_4, CardSide.BOTH, ctrl()))
+                TOGGLE_FLAG_PINK -> from(keyCode(KeyEvent.KEYCODE_5, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_5, CardSide.BOTH, ctrl()))
+                TOGGLE_FLAG_TURQUOISE -> from(keyCode(KeyEvent.KEYCODE_6, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_6, CardSide.BOTH, ctrl()))
+                TOGGLE_FLAG_PURPLE -> from(keyCode(KeyEvent.KEYCODE_7, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_7, CardSide.BOTH, ctrl()))
+                SHOW_HINT -> from(keyCode(KeyEvent.KEYCODE_H, CardSide.BOTH))
+                SHOW_ALL_HINTS -> from(keyCode(KeyEvent.KEYCODE_G, CardSide.BOTH))
+                ADD_NOTE -> from(keyCode(KeyEvent.KEYCODE_A, CardSide.BOTH))
                 else -> ArrayList()
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerButtons.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerButtons.kt
@@ -72,25 +72,25 @@ enum class AnswerButtons {
         return when (numberOfButtons) {
             2 -> {
                 when (this) {
-                    AGAIN -> ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE1
-                    GOOD -> ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE2
+                    AGAIN -> ViewerCommand.FLIP_OR_ANSWER_EASE1
+                    GOOD -> ViewerCommand.FLIP_OR_ANSWER_EASE2
                     else -> throw IllegalStateException("$numberOfButtons buttons with answer $this")
                 }
             }
             3 -> {
                 when (this) {
-                    AGAIN -> ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE1
-                    GOOD -> ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE2
-                    EASY -> ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE3
+                    AGAIN -> ViewerCommand.FLIP_OR_ANSWER_EASE1
+                    GOOD -> ViewerCommand.FLIP_OR_ANSWER_EASE2
+                    EASY -> ViewerCommand.FLIP_OR_ANSWER_EASE3
                     else -> throw IllegalStateException("$numberOfButtons buttons with answer $this")
                 }
             }
             4 -> {
                 when (this) {
-                    AGAIN -> ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE1
-                    HARD -> ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE2
-                    GOOD -> ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE3
-                    EASY -> ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE4
+                    AGAIN -> ViewerCommand.FLIP_OR_ANSWER_EASE1
+                    HARD -> ViewerCommand.FLIP_OR_ANSWER_EASE2
+                    GOOD -> ViewerCommand.FLIP_OR_ANSWER_EASE3
+                    EASY -> ViewerCommand.FLIP_OR_ANSWER_EASE4
                 }
             }
             else -> throw IllegalStateException("unexpected button count: $numberOfButtons. answer: $this")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AutomaticAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AutomaticAnswer.kt
@@ -330,7 +330,7 @@ enum class AutomaticAnswerAction(private val preferenceValue: Int) {
     /** Convert to a [ViewerCommand] */
     private fun toCommand(numberOfButtons: Int): ViewerCommand {
         return when (this) {
-            BURY_CARD -> ViewerCommand.COMMAND_BURY_CARD
+            BURY_CARD -> ViewerCommand.BURY_CARD
             ANSWER_AGAIN -> AGAIN.toViewerCommand(numberOfButtons)
             ANSWER_HARD -> HARD.toViewerCommand(numberOfButtons)
             ANSWER_GOOD -> GOOD.toViewerCommand(numberOfButtons)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -201,7 +201,7 @@ object PreferenceUpgradeService {
                 val asInt = gesture.toIntOrNull() ?: return
                 val command = ViewerCommand.fromInt(asInt) ?: return
 
-                if (command == ViewerCommand.COMMAND_NOTHING) {
+                if (command == ViewerCommand.NOTHING) {
                     return
                 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -174,7 +174,7 @@ class ControlPreference : ListPreference {
         fun setup(cat: PreferenceCategory) {
             val commands = Arrays.stream(ViewerCommand.values()).collect(Collectors.toList())
             val context = cat.context
-            commands.remove(ViewerCommand.COMMAND_NOTHING)
+            commands.remove(ViewerCommand.NOTHING)
             for (c in commands) {
                 val p = ControlPreference(context)
                 p.setTitle(c.resourceId)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerCommandTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerCommandTest.kt
@@ -47,8 +47,8 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
     @Test
     fun doubleTapSetsNone() {
         val viewer = viewer
-        viewer.executeCommand(COMMAND_TOGGLE_FLAG_RED)
-        viewer.executeCommand(COMMAND_TOGGLE_FLAG_RED)
+        viewer.executeCommand(TOGGLE_FLAG_RED)
+        viewer.executeCommand(TOGGLE_FLAG_RED)
 
         assertThat(viewer.lastFlag, `is`(FLAG_NONE))
     }
@@ -57,7 +57,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
     fun noneDoesNothing() {
         val viewer = viewer
 
-        viewer.executeCommand(COMMAND_UNSET_FLAG)
+        viewer.executeCommand(UNSET_FLAG)
 
         assertThat(viewer.lastFlag, `is`(FLAG_NONE))
     }
@@ -66,8 +66,8 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
     fun doubleNoneDoesNothing() {
         val viewer = viewer
 
-        viewer.executeCommand(COMMAND_UNSET_FLAG)
-        viewer.executeCommand(COMMAND_UNSET_FLAG)
+        viewer.executeCommand(UNSET_FLAG)
+        viewer.executeCommand(UNSET_FLAG)
 
         assertThat(viewer.lastFlag, `is`(FLAG_NONE))
     }
@@ -76,8 +76,8 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
     fun flagCanBeChanged() {
         val viewer = viewer
 
-        viewer.executeCommand(COMMAND_TOGGLE_FLAG_RED)
-        viewer.executeCommand(COMMAND_TOGGLE_FLAG_BLUE)
+        viewer.executeCommand(TOGGLE_FLAG_RED)
+        viewer.executeCommand(TOGGLE_FLAG_BLUE)
 
         assertThat(viewer.lastFlag, `is`(FLAG_BLUE))
     }
@@ -86,8 +86,8 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
     fun unsetUnsets() {
         val viewer = viewer
 
-        viewer.executeCommand(COMMAND_TOGGLE_FLAG_RED)
-        viewer.executeCommand(COMMAND_UNSET_FLAG)
+        viewer.executeCommand(TOGGLE_FLAG_RED)
+        viewer.executeCommand(UNSET_FLAG)
 
         assertThat(viewer.lastFlag, `is`(FLAG_NONE))
     }
@@ -96,7 +96,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
     fun tapRedFlagSetsRed() {
         val viewer = viewer
 
-        viewer.executeCommand(COMMAND_TOGGLE_FLAG_RED)
+        viewer.executeCommand(TOGGLE_FLAG_RED)
 
         assertThat(viewer.lastFlag, `is`(FLAG_RED))
     }
@@ -105,7 +105,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
     fun tapOrangeFlagSetsOrange() {
         val viewer = viewer
 
-        viewer.executeCommand(COMMAND_TOGGLE_FLAG_ORANGE)
+        viewer.executeCommand(TOGGLE_FLAG_ORANGE)
 
         assertThat(viewer.lastFlag, `is`(FLAG_ORANGE))
     }
@@ -114,7 +114,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
     fun tapGreenFlagSesGreen() {
         val viewer = viewer
 
-        viewer.executeCommand(COMMAND_TOGGLE_FLAG_GREEN)
+        viewer.executeCommand(TOGGLE_FLAG_GREEN)
 
         assertThat(viewer.lastFlag, `is`(FLAG_GREEN))
     }
@@ -123,7 +123,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
     fun tapBlueFlagSetsBlue() {
         val viewer = viewer
 
-        viewer.executeCommand(COMMAND_TOGGLE_FLAG_BLUE)
+        viewer.executeCommand(TOGGLE_FLAG_BLUE)
 
         assertThat(viewer.lastFlag, `is`(FLAG_BLUE))
     }
@@ -132,7 +132,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
     fun tapPinkFlagSetsPink() {
         val viewer = viewer
 
-        viewer.executeCommand(COMMAND_TOGGLE_FLAG_PINK)
+        viewer.executeCommand(TOGGLE_FLAG_PINK)
 
         assertThat(viewer.lastFlag, `is`(FLAG_PINK))
     }
@@ -141,7 +141,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
     fun tapTurquoiseFlagSetsTurquoise() {
         val viewer = viewer
 
-        viewer.executeCommand(COMMAND_TOGGLE_FLAG_TURQUOISE)
+        viewer.executeCommand(TOGGLE_FLAG_TURQUOISE)
 
         assertThat(viewer.lastFlag, `is`(FLAG_TURQUOISE))
     }
@@ -150,20 +150,20 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
     fun tapPurpleFlagSetsPurple() {
         val viewer = viewer
 
-        viewer.executeCommand(COMMAND_TOGGLE_FLAG_PURPLE)
+        viewer.executeCommand(TOGGLE_FLAG_PURPLE)
 
         assertThat(viewer.lastFlag, `is`(FLAG_PURPLE))
     }
 
     @Test
     fun doubleTapUnsets() {
-        testDoubleTapUnsets(COMMAND_TOGGLE_FLAG_RED)
-        testDoubleTapUnsets(COMMAND_TOGGLE_FLAG_ORANGE)
-        testDoubleTapUnsets(COMMAND_TOGGLE_FLAG_GREEN)
-        testDoubleTapUnsets(COMMAND_TOGGLE_FLAG_BLUE)
-        testDoubleTapUnsets(COMMAND_TOGGLE_FLAG_PINK)
-        testDoubleTapUnsets(COMMAND_TOGGLE_FLAG_TURQUOISE)
-        testDoubleTapUnsets(COMMAND_TOGGLE_FLAG_PURPLE)
+        testDoubleTapUnsets(TOGGLE_FLAG_RED)
+        testDoubleTapUnsets(TOGGLE_FLAG_ORANGE)
+        testDoubleTapUnsets(TOGGLE_FLAG_GREEN)
+        testDoubleTapUnsets(TOGGLE_FLAG_BLUE)
+        testDoubleTapUnsets(TOGGLE_FLAG_PINK)
+        testDoubleTapUnsets(TOGGLE_FLAG_TURQUOISE)
+        testDoubleTapUnsets(TOGGLE_FLAG_PURPLE)
     }
 
     private fun testDoubleTapUnsets(command: ViewerCommand) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerSoundRenderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerSoundRenderTest.kt
@@ -46,7 +46,7 @@ class AbstractFlashcardViewerSoundRenderTest : RobolectricTest() {
 
         assertThat(sounds.q(), hasSize(1))
 
-        sounds.executeCommand(ViewerCommand.COMMAND_SHOW_ANSWER)
+        sounds.executeCommand(ViewerCommand.SHOW_ANSWER)
 
         assertThat(sounds.q(), hasSize(1))
         assertThat(sounds.a(), nullValue())
@@ -59,7 +59,7 @@ class AbstractFlashcardViewerSoundRenderTest : RobolectricTest() {
 
         assertThat(sounds.q(), nullValue())
 
-        sounds.executeCommand(ViewerCommand.COMMAND_SHOW_ANSWER)
+        sounds.executeCommand(ViewerCommand.SHOW_ANSWER)
 
         assertThat(sounds.q(), nullValue())
         assertThat(sounds.a(), hasSize(1))
@@ -72,7 +72,7 @@ class AbstractFlashcardViewerSoundRenderTest : RobolectricTest() {
 
         assertThat(sounds.q(), hasSize(1))
 
-        sounds.executeCommand(ViewerCommand.COMMAND_SHOW_ANSWER)
+        sounds.executeCommand(ViewerCommand.SHOW_ANSWER)
 
         assertThat(sounds.q(), hasSize(1))
         assertThat(sounds.a(), hasSize(1))
@@ -85,7 +85,7 @@ class AbstractFlashcardViewerSoundRenderTest : RobolectricTest() {
 
         assertThat(sounds.q(), hasSize(1))
 
-        sounds.executeCommand(ViewerCommand.COMMAND_SHOW_ANSWER)
+        sounds.executeCommand(ViewerCommand.SHOW_ANSWER)
 
         assertThat(sounds.q(), hasSize(1))
         assertThat(sounds.a(), hasSize(1))
@@ -98,7 +98,7 @@ class AbstractFlashcardViewerSoundRenderTest : RobolectricTest() {
 
         assertThat(sounds.q(), hasSize(2))
 
-        sounds.executeCommand(ViewerCommand.COMMAND_SHOW_ANSWER)
+        sounds.executeCommand(ViewerCommand.SHOW_ANSWER)
 
         assertThat(sounds.q(), hasSize(2))
         assertThat(sounds.a(), hasSize(1))
@@ -111,7 +111,7 @@ class AbstractFlashcardViewerSoundRenderTest : RobolectricTest() {
 
         assertThat(sounds.q(), hasSize(1))
 
-        sounds.executeCommand(ViewerCommand.COMMAND_SHOW_ANSWER)
+        sounds.executeCommand(ViewerCommand.SHOW_ANSWER)
 
         assertThat(sounds.q(), hasSize(1))
         assertThat(sounds.a(), hasSize(1))
@@ -124,7 +124,7 @@ class AbstractFlashcardViewerSoundRenderTest : RobolectricTest() {
 
         assertThat(sounds.q(), hasSize(1))
 
-        sounds.executeCommand(ViewerCommand.COMMAND_SHOW_ANSWER)
+        sounds.executeCommand(ViewerCommand.SHOW_ANSWER)
 
         assertThat(sounds.q(), hasSize(1))
         assertThat(sounds.a(), hasSize(1))
@@ -137,7 +137,7 @@ class AbstractFlashcardViewerSoundRenderTest : RobolectricTest() {
 
         assertThat(sounds.q(), nullValue())
 
-        sounds.executeCommand(ViewerCommand.COMMAND_SHOW_ANSWER)
+        sounds.executeCommand(ViewerCommand.SHOW_ANSWER)
 
         assertThat(sounds.q(), nullValue())
         assertThat(sounds.a(), hasSize(1))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -162,11 +162,11 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
         val viewer: NonAbstractFlashcardViewer = getViewer(true)
 
         assertThat("Displaying question", viewer.isDisplayingAnswer, equalTo(false))
-        viewer.executeCommand(ViewerCommand.COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
+        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
 
         assertThat("Displaying answer", viewer.isDisplayingAnswer, equalTo(true))
 
-        viewer.executeCommand(ViewerCommand.COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
+        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
 
         assertThat(viewer.answered, notNullValue())
     }
@@ -211,7 +211,7 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
         val controller = getViewerController(true, false)
         val viewer = controller.get()
         viewer.mAutomaticAnswer = AutomaticAnswer(viewer, AutomaticAnswerSettings(AutomaticAnswerAction.BURY_CARD, true, 5, 5))
-        viewer.executeCommand(ViewerCommand.COMMAND_SHOW_ANSWER)
+        viewer.executeCommand(ViewerCommand.SHOW_ANSWER)
         assertThat("messages after flipping card", viewer.hasAutomaticAnswerQueued(), equalTo(true))
         controller.pause()
         assertThat("disabled after pause", viewer.mAutomaticAnswer.isDisabled, equalTo(true))
@@ -223,14 +223,14 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
     @Test
     fun shortcutShowsToastOnFinish() {
         val viewer: NonAbstractFlashcardViewer = getViewer(true, true)
-        viewer.executeCommand(ViewerCommand.COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
-        viewer.executeCommand(ViewerCommand.COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
+        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
+        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
         assertEquals(getResourceString(R.string.studyoptions_congrats_finished), ShadowToast.getTextOfLatestToast())
     }
 
     private fun showNextCard(viewer: NonAbstractFlashcardViewer) {
-        viewer.executeCommand(ViewerCommand.COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
-        viewer.executeCommand(ViewerCommand.COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
+        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
+        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
     }
 
     @get:CheckResult

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
@@ -153,7 +153,7 @@ class ReviewerNoParamTest : RobolectricTest() {
 
         val hideCount = reviewer.delayedHideCount
 
-        reviewer.executeCommand(ViewerCommand.COMMAND_UNDO)
+        reviewer.executeCommand(ViewerCommand.UNDO)
         advanceRobolectricLooperWithSleep()
 
         assertThat("Hide should be called after answering a card", reviewer.delayedHideCount, greaterThan(hideCount))
@@ -275,7 +275,7 @@ class ReviewerNoParamTest : RobolectricTest() {
         AnkiDroidApp.getSharedPrefs(targetContext).edit {
             for (g in gestures) {
                 val k = getKey(g)
-                putString(k, ViewerCommand.COMMAND_NOTHING.toPreferenceString())
+                putString(k, ViewerCommand.NOTHING.toPreferenceString())
             }
         }
     }
@@ -284,7 +284,7 @@ class ReviewerNoParamTest : RobolectricTest() {
     private fun enableGesture(gesture: Gesture) {
         AnkiDroidApp.getSharedPrefs(targetContext).edit {
             val k = getKey(gesture)
-            putString(k, ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE1.toPreferenceString())
+            putString(k, ViewerCommand.FLIP_OR_ANSWER_EASE1.toPreferenceString())
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -80,7 +80,7 @@ class ReviewerTest : RobolectricTest() {
         ActivityScenario.launch(Reviewer::class.java).use { scenario ->
             scenario.onActivity { reviewer: Reviewer ->
                 reviewer.blockControls(true)
-                reviewer.executeCommand(ViewerCommand.COMMAND_EXIT)
+                reviewer.executeCommand(ViewerCommand.EXIT)
             }
             assertThat(scenario.result.resultCode, equalTo(RESULT_DEFAULT))
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/GestureProcessorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/GestureProcessorTest.kt
@@ -49,7 +49,7 @@ class GestureProcessorTest : ViewerCommand.CommandProcessor {
         every { prefs.getBoolean("gestureCornerTouch", any()) } returns true
         mSut.init(prefs)
         mSut.onTap(100, 100, 50f, 50f)
-        assertThat(singleResult(), equalTo(ViewerCommand.COMMAND_SHOW_ANSWER))
+        assertThat(singleResult(), equalTo(ViewerCommand.SHOW_ANSWER))
     }
 
     companion object {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AnswerButtonsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AnswerButtonsTest.kt
@@ -29,9 +29,9 @@ class AnswerButtonsTest {
     @Test
     fun checkTwoButtons() {
         val numberOfButtons = 2
-        assertThat(AGAIN.toViewerCommand(numberOfButtons), equalTo(ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE1))
+        assertThat(AGAIN.toViewerCommand(numberOfButtons), equalTo(ViewerCommand.FLIP_OR_ANSWER_EASE1))
         assertThat("hard", canAnswerHard(numberOfButtons), equalTo(false))
-        assertThat(GOOD.toViewerCommand(numberOfButtons), equalTo(ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE2))
+        assertThat(GOOD.toViewerCommand(numberOfButtons), equalTo(ViewerCommand.FLIP_OR_ANSWER_EASE2))
         assertThat("easy", canAnswerEasy(numberOfButtons), equalTo(false))
     }
 
@@ -39,10 +39,10 @@ class AnswerButtonsTest {
     fun checkThreeButtons() {
         val numberOfButtons = 3
 
-        assertThat(AGAIN.toViewerCommand(numberOfButtons), equalTo(ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE1))
+        assertThat(AGAIN.toViewerCommand(numberOfButtons), equalTo(ViewerCommand.FLIP_OR_ANSWER_EASE1))
         assertThat("hard", canAnswerHard(numberOfButtons), equalTo(false))
-        assertThat(GOOD.toViewerCommand(numberOfButtons), equalTo(ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE2))
-        assertThat(EASY.toViewerCommand(numberOfButtons), equalTo(ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE3))
+        assertThat(GOOD.toViewerCommand(numberOfButtons), equalTo(ViewerCommand.FLIP_OR_ANSWER_EASE2))
+        assertThat(EASY.toViewerCommand(numberOfButtons), equalTo(ViewerCommand.FLIP_OR_ANSWER_EASE3))
 
         assertThat("easy", canAnswerEasy(numberOfButtons), equalTo(true))
     }
@@ -51,10 +51,10 @@ class AnswerButtonsTest {
     fun checkFourButtons() {
         val numberOfButtons = 4
 
-        assertThat(AGAIN.toViewerCommand(numberOfButtons), equalTo(ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE1))
-        assertThat(HARD.toViewerCommand(numberOfButtons), equalTo(ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE2))
-        assertThat(GOOD.toViewerCommand(numberOfButtons), equalTo(ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE3))
-        assertThat(EASY.toViewerCommand(numberOfButtons), equalTo(ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE4))
+        assertThat(AGAIN.toViewerCommand(numberOfButtons), equalTo(ViewerCommand.FLIP_OR_ANSWER_EASE1))
+        assertThat(HARD.toViewerCommand(numberOfButtons), equalTo(ViewerCommand.FLIP_OR_ANSWER_EASE2))
+        assertThat(GOOD.toViewerCommand(numberOfButtons), equalTo(ViewerCommand.FLIP_OR_ANSWER_EASE3))
+        assertThat(EASY.toViewerCommand(numberOfButtons), equalTo(ViewerCommand.FLIP_OR_ANSWER_EASE4))
 
         assertThat("easy", canAnswerEasy(numberOfButtons), equalTo(true))
         assertThat("hard", canAnswerHard(numberOfButtons), equalTo(true))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerActionTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerActionTest.kt
@@ -18,7 +18,6 @@ package com.ichi2.anki.reviewer
 
 import com.ichi2.anki.Reviewer
 import com.ichi2.anki.cardviewer.ViewerCommand
-import com.ichi2.anki.cardviewer.ViewerCommand.*
 import com.ichi2.anki.reviewer.AutomaticAnswerAction.*
 import com.ichi2.anki.reviewer.AutomaticAnswerAction.Companion.fromPreferenceValue
 import org.hamcrest.CoreMatchers.equalTo
@@ -41,23 +40,23 @@ class AutomaticAnswerActionTest {
 
     @Test
     fun testExecute() {
-        assertExecuteReturns(BURY_CARD, 2, COMMAND_BURY_CARD)
+        assertExecuteReturns(BURY_CARD, 2, ViewerCommand.BURY_CARD)
 
         // easy and hard are mapped to "good" if they don't exist
-        assertExecuteReturns(ANSWER_AGAIN, 2, COMMAND_FLIP_OR_ANSWER_EASE1)
-        assertExecuteReturns(ANSWER_HARD, 2, COMMAND_FLIP_OR_ANSWER_EASE2)
-        assertExecuteReturns(ANSWER_GOOD, 2, COMMAND_FLIP_OR_ANSWER_EASE2)
-        assertExecuteReturns(ANSWER_EASY, 2, COMMAND_FLIP_OR_ANSWER_EASE2)
+        assertExecuteReturns(ANSWER_AGAIN, 2, ViewerCommand.FLIP_OR_ANSWER_EASE1)
+        assertExecuteReturns(ANSWER_HARD, 2, ViewerCommand.FLIP_OR_ANSWER_EASE2)
+        assertExecuteReturns(ANSWER_GOOD, 2, ViewerCommand.FLIP_OR_ANSWER_EASE2)
+        assertExecuteReturns(ANSWER_EASY, 2, ViewerCommand.FLIP_OR_ANSWER_EASE2)
 
-        assertExecuteReturns(ANSWER_AGAIN, 3, COMMAND_FLIP_OR_ANSWER_EASE1)
-        assertExecuteReturns(ANSWER_HARD, 3, COMMAND_FLIP_OR_ANSWER_EASE2)
-        assertExecuteReturns(ANSWER_GOOD, 3, COMMAND_FLIP_OR_ANSWER_EASE2)
-        assertExecuteReturns(ANSWER_EASY, 3, COMMAND_FLIP_OR_ANSWER_EASE3)
+        assertExecuteReturns(ANSWER_AGAIN, 3, ViewerCommand.FLIP_OR_ANSWER_EASE1)
+        assertExecuteReturns(ANSWER_HARD, 3, ViewerCommand.FLIP_OR_ANSWER_EASE2)
+        assertExecuteReturns(ANSWER_GOOD, 3, ViewerCommand.FLIP_OR_ANSWER_EASE2)
+        assertExecuteReturns(ANSWER_EASY, 3, ViewerCommand.FLIP_OR_ANSWER_EASE3)
 
-        assertExecuteReturns(ANSWER_AGAIN, 4, COMMAND_FLIP_OR_ANSWER_EASE1)
-        assertExecuteReturns(ANSWER_HARD, 4, COMMAND_FLIP_OR_ANSWER_EASE2)
-        assertExecuteReturns(ANSWER_GOOD, 4, COMMAND_FLIP_OR_ANSWER_EASE3)
-        assertExecuteReturns(ANSWER_EASY, 4, COMMAND_FLIP_OR_ANSWER_EASE4)
+        assertExecuteReturns(ANSWER_AGAIN, 4, ViewerCommand.FLIP_OR_ANSWER_EASE1)
+        assertExecuteReturns(ANSWER_HARD, 4, ViewerCommand.FLIP_OR_ANSWER_EASE2)
+        assertExecuteReturns(ANSWER_GOOD, 4, ViewerCommand.FLIP_OR_ANSWER_EASE3)
+        assertExecuteReturns(ANSWER_EASY, 4, ViewerCommand.FLIP_OR_ANSWER_EASE4)
     }
 
     private fun assertExecuteReturns(action: AutomaticAnswerAction, numberOfButtons: Int, expectedCommand: ViewerCommand) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.kt
@@ -44,7 +44,7 @@ class PeripheralKeymapTest {
         peripheralKeymap.onKeyDown(KeyEvent.KEYCODE_1, event)
 
         assertThat<List<ViewerCommand>>(processed, hasSize(1))
-        assertThat(processed[0], equalTo(ViewerCommand.COMMAND_TOGGLE_FLAG_RED))
+        assertThat(processed[0], equalTo(ViewerCommand.TOGGLE_FLAG_RED))
     }
 
     private class MockReviewerUi : ReviewerUi {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeVolumeButtonsToBindingsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeVolumeButtonsToBindingsTest.kt
@@ -66,9 +66,9 @@ class UpgradeVolumeButtonsToBindingsTest(private val testData: TestData) : Robol
     @Test
     fun test_preferences_opened_happy_path() {
         // the default is that the user has not mapped the gesture, but has opened the screen
-        // so they are set to COMMAND_NOTHING
-        prefs.edit { putString(PREF_KEY_VOLUME_UP, ViewerCommand.COMMAND_NOTHING.toPreferenceString()) }
-        prefs.edit { putString(PREF_KEY_VOLUME_DOWN, ViewerCommand.COMMAND_NOTHING.toPreferenceString()) }
+        // so they are set to NOTHING
+        prefs.edit { putString(PREF_KEY_VOLUME_UP, ViewerCommand.NOTHING.toPreferenceString()) }
+        prefs.edit { putString(PREF_KEY_VOLUME_DOWN, ViewerCommand.NOTHING.toPreferenceString()) }
 
         assertThat(prefs.contains(PREF_KEY_VOLUME_DOWN), equalTo(true))
         assertThat(prefs.contains(PREF_KEY_VOLUME_UP), equalTo(true))
@@ -85,7 +85,7 @@ class UpgradeVolumeButtonsToBindingsTest(private val testData: TestData) : Robol
     @Test
     fun gesture_set_no_conflicts() {
         // assume that we have a preference set, and that it has no defaults
-        val command = ViewerCommand.COMMAND_SHOW_ANSWER
+        val command = ViewerCommand.SHOW_ANSWER
         prefs.edit { putString(testData.affectedPreferenceKey, command.toPreferenceString()) }
 
         assertThat(prefs.contains(testData.affectedPreferenceKey), equalTo(true))
@@ -112,7 +112,7 @@ class UpgradeVolumeButtonsToBindingsTest(private val testData: TestData) : Robol
         // common path
         // if the gesture was mapped to a command which already had bindings,
         // check it is added to the list at the end
-        val command = ViewerCommand.COMMAND_EDIT
+        val command = ViewerCommand.EDIT
         prefs.edit { putString(testData.affectedPreferenceKey, command.toPreferenceString()) }
 
         assertThat(prefs.contains(testData.affectedPreferenceKey), equalTo(true))
@@ -147,7 +147,7 @@ class UpgradeVolumeButtonsToBindingsTest(private val testData: TestData) : Robol
         // the gestures shouldn't already be a keybind (as we've just introduced the feature)
         // but if it is, then we want to ignore it in the upgrade.
 
-        val command = ViewerCommand.COMMAND_EDIT
+        val command = ViewerCommand.EDIT
         command.addBinding(prefs, testData.binding)
 
         prefs.edit { putString(testData.affectedPreferenceKey, command.toPreferenceString()) }


### PR DESCRIPTION
They were redundant as the class is a Enum called ViewerCommand

And avoids wasting processing when building the preferenceKey

## Pull Request template

## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
Fixes _Link to the issues._

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
